### PR TITLE
sambamba_merge implemented and working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,15 @@ supplementary/betas/.
 # scratch files from script development
 src/scratch/.
 
+# scratch files from rule development
+/pipeline/rules/scratch/.
+
+# temporary files
+*.tmp
+*.temp
+tmp/*
+temp/*
+
 # OS generated files #
 ######################
 .DS_Store
@@ -22,6 +31,8 @@ src/scratch/.
 /pipeline/pre-processing/logs/.
 /pipeline/pre-processing/.snakemake/.
 
+# python cache files
+__pycache__/.
 
 # stderr and stdout from scripts
 *.err

--- a/pipeline/cluster.yaml
+++ b/pipeline/cluster.yaml
@@ -77,7 +77,12 @@ bismark_mapping_pe:
     mem_mb: 20000
 
 sambamba_sort_index_markdups:
-    time: 0-20:00:00
-    mem_mb: 20000
-    cpus-per-task: 8
+    time: 0-10:00:00
+    mem_mb: 8000
+    cpus-per-task: 4
+
+sambamba_merge:
+    time: 0-10:00:00
+    mem_mb: 8000
+    cpus-per-task: 4
                                                                

--- a/pipeline/pre-processing/subworkflow_functions.py
+++ b/pipeline/pre-processing/subworkflow_functions.py
@@ -1,0 +1,58 @@
+import pandas as pd
+
+#### Python functions for snakemake pipeline ####
+
+''' Read sample info table into pandas dataframe and confirm column names that are needed for the pipeline'''
+def get_sample_info_df(input_tsv):
+    sample_info = pd.read_table(input_tsv, dtype=str)
+    # Verify column names
+    if not {'ref', 'patient_id', 'srx_id', 'accession', 'layout', 'group', 'age', 'sex', 'ethnicity'}.issubset(sample_info.columns.values):
+        raise KeyError("The sample info file must contain the following named columns: 'ref', 'patient_id', 'srx_id', 'accession', 'layout', 'group', 'age', 'sex' 'ethnicity'")
+    sample_info = sample_info.set_index(["srx_id"], drop=False)
+    return sample_info
+
+''' Get list of accessions for a given srx_id and determine if a merge is needed for bam files associated with that srx_id'''
+def accession_list_by_srx_id(sample_info_df, srx_id):
+    srx_samples = sample_info_df[sample_info_df['srx_id'] == srx_id]
+    accessions = srx_samples['accession'].tolist()
+    # if len(accessions) > 1:
+    #     print("More than 1 run provided for srx_id = {}: \n Merge needed for bam files of accessions = {}".format(srx_id, accessions))
+    # if len(accessions) == 1:
+    #     print("Only 1 run provided for srx_id = {}. \n Merge not needed for accession = {}".format(srx_id, accessions))
+    if len(accessions) == 0:
+        raise KeyError("ERROR: No accessions provided for runs from srx_id = {}".format(srx_id))
+    return accessions
+
+''' Make a dictionary of srx_id and associated accessions'''
+def make_srx_accession_dict(sample_info_df):
+    srx_id_list = sample_info_df['srx_id'].unique().tolist()
+    srx_acc_dict = {}
+    for srx_id in srx_id_list:
+        accessions = accession_list_by_srx_id(sample_info_df, srx_id)
+        srx_acc_dict[srx_id] = (accessions)
+    return srx_acc_dict
+
+''' Make a dictionary of srx_id and associated pandas dataframe rows'''
+def make_srx_df_dict(sample_info_df):
+    srx_id_list = sample_info_df['srx_id'].unique().tolist()
+    srx_df_dict = {}
+    for srx_id in srx_id_list:
+        srx_df_dict[srx_id] = sample_info_df[sample_info_df['srx_id'] == srx_id]
+    return srx_df_dict
+
+''' drop the accessions column from the dataframe and merge the rows into a single row'''
+def merge_rows_by_srx_id(srx_df_dict):
+    merged_df_dict = {}
+    for srx_id, df in srx_df_dict.items():
+        df = df.drop(columns=['accession'])
+        df = df.drop_duplicates()
+        merged_df_dict[srx_id] = df
+        if len(df) > 1:
+            raise ValueError("ERROR: All df samlpe details for srx_id = {} should be the same except accession because srx_id represents an experiment and is unique to one sample. This allows for sample information to be collapsed by srx_id when accessions are removed. Please check the sample info file for discrepancies in columns with srx_id={}.".format(srx_id, srx_id))
+    return merged_df_dict
+
+''' Return a reduced df for for sample info by srx_id'''
+def get_sample_info_by_srx_id(sample_info_df):
+    sample_info_by_srx = sample_info_df.drop(columns=['accession'])
+    sample_info_by_srx = sample_info_by_srx.drop_duplicates()
+    return sample_info_by_srx

--- a/pipeline/rules/0_sambamba_merge.smk
+++ b/pipeline/rules/0_sambamba_merge.smk
@@ -1,0 +1,40 @@
+
+# # has benn tested with files that do not need to be merged
+# # still need to test rule for sambamba merge with files that need to be merged
+# symlinks were experiencing latency wait time errors. To avoid specifying latency wait time for all jobs, I added a sleep 10 seconds command to the shell script. This will allow the symlink to be created before the next rule_all is executed.
+
+rule sambamba_merge:
+    input:
+       bams = lambda wildcards: expand("{data_dir}/trimmed/trim_galore/aligned/bwameth/deduped/sambamba/{{ref}}/{{patient_id}}/{{group}}-{{srx_id}}-{{layout}}/{accession}_trimmed_sorted_dedup.bam", data_dir=config["data"]["dir"], accession = sample_info[sample_info["srx_id"] == wildcards.srx_id]["accession"].tolist())
+    
+    output:
+        merged_bam = expand("{data_dir}/trimmed/trim_galore/aligned/bwameth/deduped/sambamba/merged/{{ref}}-{{patient_id}}-{{group}}-{{srx_id}}-{{layout}}_merged.bam", data_dir=config["data"]["dir"])
+
+    log:
+        "../pre-processing/logs/rule-logs/sambamba_merge/{ref}/sambamba_merge-{ref}-{patient_id}-{group}-{srx_id}-{layout}.log"
+
+    conda:
+        "../env/sambamba.yaml"
+
+    threads: 3
+    
+    wildcard_constraints:
+        srx_id = "|".join(sample_info["srx_id"].tolist()),
+        accession = "|".join(sample_info["accession"].tolist())
+
+    shell:
+        """
+        FILES=()
+        for i in {input.bams}; do
+            FILES+=($i)
+        done
+        input_len=${{#FILES[@]}}
+        if [ $input_len -gt 1 ]; then
+            echo "Merging files: {input.bams} into {output.merged_bam} with sambamba merge..." > {log}
+            sambamba merge -t {threads} {output.merged_bam} {input.bams} >> {log} 2>> {log}
+        else
+            echo "Only one file, no need to merge. Creating symlink for file at expected output location: {output.merged_bam}" > {log}
+            ln -sr {input.bams} {output.merged_bam}
+        fi
+        sleep 10
+        """


### PR DESCRIPTION
Implemented sambamba sorting and indexing rule, which is functional and integrated into pipeline. Implemented sambamba merge rule: This was tricky and required a subset of bam files with different accession numbers that were from same srx_id to be given as inputs. Wildcard constraints were added to help with ambiguity errors from snakemake. The rule will specify if merging is needed based on the number of files associated with the srx_id. If no merging is needed, the rule will create a symbolic link at the expected output location, otherwise files will be merged with sambamba. The single file method has been tested with the small subset of data, but the smabamba merge command still needs to be tested.

Next steps include rules for reporting samtools flagstats and multiqc reporting. Additionally, methylation calling is needed with wgbstools and potentially bismark to complete the pre-processing pipeline as a subworkflow for the larger pipeline, which will find differentially methylated regions between sample groups and annotations to determine differentially methylated groups in the test group.